### PR TITLE
Fix unsigned int casting error

### DIFF
--- a/fastdet/corr_detector.cpp
+++ b/fastdet/corr_detector.cpp
@@ -146,7 +146,7 @@ CorrDetection CorrDetector::detect(const complex<float> *shifted_fft,
                                       corr_len_);
 
     // Get peak
-    unsigned int peak_idx;
+    uint16_t peak_idx;
     volk_32f_index_max_16u(
             (uint16_t*)&peak_idx,
             corr_power_.data() + start_idx_,


### PR DESCRIPTION
Hello,

My team and I have been using your thesis and your code for our engineering capstone project.
Your code has performed almost flawlessly, except for the occasional segfault around the time
the first detection.

I tracked the error down to this libvolk call. For some reason, GCC doesn't choose the right unsigned integer size. This leads to indexing an array with a partially uninitialized integer further down the code, causing the segfault.

This PR changes the type of that integer to the more explicit type `uint16_t`.