### PR TITLE
Fastdet: Flush to toad file every newline

### DIFF
--- a/fastdet/fastdet.cpp
+++ b/fastdet/fastdet.cpp
@@ -204,6 +204,7 @@ int main(int argc, char **argv) {
                                sqrt(carrier.detection.max),
                                sqrt(carrier.detection.noise)
                                );
+                    out.flush();
                 }
 
                 if (card.file() != NULL) {


### PR DESCRIPTION
Hi Again,

My team and I require that detections are reported in (somewhat) realtime.
Fastdet's current behavior is to buffer around 4096 characters before actually writing to the toad file.

This PR forces a flush of the file buffer after every line produced by fastdet.